### PR TITLE
Fix for overflowing long patterns.

### DIFF
--- a/html5pattern/css/style.css
+++ b/html5pattern/css/style.css
@@ -97,6 +97,7 @@ h1 {
 .patterngate {border-radius:3px;width:550px;margin-bottom:20px;background-color:#efefef;vertical-align:top;padding:10px;}
 .patterngate:hover {background-color:#cfcfcf;}
 .patterngate h2 {margin-top:0;padding-top:0;}
+.patterngate pre {overflow: scroll;}
 .leftside {float:left;width:330px;margin-right:20px;}
 .rightside {width:180px;float:left;}
 pre {background:snow;padding:5px 3px;overflow: hidden;text-overflow: ellipsis;white-space: nowrap;}
@@ -140,7 +141,7 @@ form#f label {
 
 form#f hr {
     margin:10px auto;
-    
+
     font-size: 0px; line-height: 0%; width: 0px;
     border-top: 40px solid #888;
     border-left: 250px solid transparent;


### PR DESCRIPTION
Problem: 
<img width="899" alt="screen shot 2016-01-15 at 00 42 46" src="https://cloud.githubusercontent.com/assets/138194/12342359/aa2f5f6c-bb21-11e5-9ae0-edf8b3108184.png">

With this, patterns still can be copied etc. 
No regression, just ugly 'thing' is no longer ugly.

After:

<img width="672" alt="screen shot 2016-01-15 at 00 49 20" src="https://cloud.githubusercontent.com/assets/138194/12342394/e804631e-bb21-11e5-8bf9-00462d463f30.png">
